### PR TITLE
fix: Copy container output into only stdout

### DIFF
--- a/docker_util.go
+++ b/docker_util.go
@@ -125,5 +125,4 @@ func AttachContainer(ctx context.Context, clnt *client.Client, cid string) {
 	CheckError(err)
 
 	go io.Copy(os.Stdout, resp.Reader)
-	go io.Copy(os.Stderr, resp.Reader)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/laterality/spring-guestbook/db-migration
+module github.com/laterality/hysteresis
 
 go 1.13
 


### PR DESCRIPTION
* 컨테이너 출력을 stderr에 복사하지 않도록 수정
* go.mod의 모듈명 변경